### PR TITLE
Add file/package configuration options when generating `service.go`

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Exec              PackageConfig              `yaml:"exec"`
 	Model             PackageConfig              `yaml:"model"`
 	Resolver          PackageConfig              `yaml:"resolver,omitempty"`
+	Service           PackageConfig              `yaml:"service,omitempty"`
 	AutoBind          []string                   `yaml:"autobind"`
 	Models            TypeMap                    `yaml:"models,omitempty"`
 	StructTag         string                     `yaml:"struct_tag,omitempty"`
@@ -39,6 +40,7 @@ func DefaultConfig() *Config {
 		SchemaFilename: StringList{"schema.graphql"},
 		Model:          PackageConfig{Filename: "models_gen.go"},
 		Exec:           PackageConfig{Filename: "generated.go"},
+		Service:        PackageConfig{Filename: "service.go"},
 		Directives:     map[string]DirectiveConfig{},
 	}
 }
@@ -236,6 +238,11 @@ func (c *Config) Check() error {
 			return errors.Wrap(err, "config.resolver")
 		}
 	}
+	if c.Service.IsDefined() {
+		if err := c.Service.Check(); err != nil {
+			return errors.Wrap(err, "config.service")
+		}
+	}
 
 	// check packages names against conflict, if present in the same dir
 	// and check filenames for uniqueness
@@ -243,6 +250,7 @@ func (c *Config) Check() error {
 		c.Model,
 		c.Exec,
 		c.Resolver,
+		c.Service,
 	}
 	filesMap := make(map[string]bool)
 	pkgConfigsByDir := make(map[string]PackageConfig)
@@ -375,6 +383,12 @@ func (c *Config) normalize() error {
 	if c.Resolver.IsDefined() {
 		if err := c.Resolver.normalize(); err != nil {
 			return errors.Wrap(err, "resolver")
+		}
+	}
+
+	if c.Service.IsDefined() {
+		if err := c.Service.normalize(); err != nil {
+			return errors.Wrap(err, "service")
 		}
 	}
 

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -10,24 +10,25 @@ import (
 	"sort"
 	"strings"
 
-	"golang.org/x/tools/go/packages"
-
 	"github.com/99designs/gqlgen/internal/code"
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser"
 	"github.com/vektah/gqlparser/ast"
+	"golang.org/x/tools/go/packages"
 	"gopkg.in/yaml.v2"
 )
 
 type Config struct {
-	SchemaFilename StringList                 `yaml:"schema,omitempty"`
-	Exec           PackageConfig              `yaml:"exec"`
-	Model          PackageConfig              `yaml:"model"`
-	Resolver       PackageConfig              `yaml:"resolver,omitempty"`
-	AutoBind       []string                   `yaml:"autobind"`
-	Models         TypeMap                    `yaml:"models,omitempty"`
-	StructTag      string                     `yaml:"struct_tag,omitempty"`
-	Directives     map[string]DirectiveConfig `yaml:"directives,omitempty"`
+	SchemaFilename    StringList                 `yaml:"schema,omitempty"`
+	Exec              PackageConfig              `yaml:"exec"`
+	Model             PackageConfig              `yaml:"model"`
+	Resolver          PackageConfig              `yaml:"resolver,omitempty"`
+	AutoBind          []string                   `yaml:"autobind"`
+	Models            TypeMap                    `yaml:"models,omitempty"`
+	StructTag         string                     `yaml:"struct_tag,omitempty"`
+	Directives        map[string]DirectiveConfig `yaml:"directives,omitempty"`
+	Federated         bool                       `yaml:"federated,omitempty"`
+	AdditionalSources []*ast.Source              `yaml:"-"`
 }
 
 var cfgFilenames = []string{".gqlgen.yml", "gqlgen.yml", "gqlgen.yaml"}
@@ -456,12 +457,9 @@ func (c *Config) InjectBuiltins(s *ast.Schema) {
 	}
 }
 
-func (c *Config) LoadSchema() (*ast.Schema, map[string]string, error) {
-	schemaStrings := map[string]string{}
-
-	sources := make([]*ast.Source, len(c.SchemaFilename))
-
-	for i, filename := range c.SchemaFilename {
+func (c *Config) LoadSchema() (*ast.Schema, error) {
+	sources := append([]*ast.Source{}, c.AdditionalSources...)
+	for _, filename := range c.SchemaFilename {
 		filename = filepath.ToSlash(filename)
 		var err error
 		var schemaRaw []byte
@@ -470,15 +468,13 @@ func (c *Config) LoadSchema() (*ast.Schema, map[string]string, error) {
 			fmt.Fprintln(os.Stderr, "unable to open schema: "+err.Error())
 			os.Exit(1)
 		}
-		schemaStrings[filename] = string(schemaRaw)
-		sources[i] = &ast.Source{Name: filename, Input: schemaStrings[filename]}
+		sources = append(sources, &ast.Source{Name: filename, Input: string(schemaRaw)})
 	}
-
 	schema, err := gqlparser.LoadSchema(sources...)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return schema, schemaStrings, nil
+	return schema, nil
 }
 
 func abs(path string) string {

--- a/codegen/data.go
+++ b/codegen/data.go
@@ -1,12 +1,14 @@
 package codegen
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/ast"
+	"github.com/vektah/gqlparser/formatter"
 )
 
 // Data is a unified model of the code to be generated. Plugins may modify this structure to do things like implement
@@ -35,13 +37,17 @@ type builder struct {
 	Directives map[string]*Directive
 }
 
-func BuildData(cfg *config.Config) (*Data, error) {
+type SchemaMutator interface {
+	MutateSchema(s *ast.Schema) error
+}
+
+func BuildData(cfg *config.Config, plugins []SchemaMutator) (*Data, error) {
 	b := builder{
 		Config: cfg,
 	}
 
 	var err error
-	b.Schema, b.SchemaStr, err = cfg.LoadSchema()
+	b.Schema, err = cfg.LoadSchema()
 	if err != nil {
 		return nil, err
 	}
@@ -57,6 +63,10 @@ func BuildData(cfg *config.Config) (*Data, error) {
 	}
 
 	cfg.InjectBuiltins(b.Schema)
+
+	for _, p := range plugins {
+		p.MutateSchema(b.Schema)
+	}
 
 	b.Binder, err = b.Config.NewBinder(b.Schema)
 	if err != nil {
@@ -132,6 +142,10 @@ func BuildData(cfg *config.Config) (*Data, error) {
 	sort.Slice(s.Inputs, func(i, j int) bool {
 		return s.Inputs[i].Definition.Name < s.Inputs[j].Definition.Name
 	})
+
+	var buf bytes.Buffer
+	formatter.NewFormatter(&buf).FormatSchema(b.Schema)
+	s.SchemaStr = map[string]string{"schema.graphql": buf.String()}
 
 	return &s, nil
 }

--- a/codegen/data.go
+++ b/codegen/data.go
@@ -65,7 +65,10 @@ func BuildData(cfg *config.Config, plugins []SchemaMutator) (*Data, error) {
 	cfg.InjectBuiltins(b.Schema)
 
 	for _, p := range plugins {
-		p.MutateSchema(b.Schema)
+		err = p.MutateSchema(b.Schema)
+		if err != nil {
+			return nil, fmt.Errorf("error running MutateSchema: %v", err)
+		}
 	}
 
 	b.Binder, err = b.Config.NewBinder(b.Schema)

--- a/codegen/directives.gotpl
+++ b/codegen/directives.gotpl
@@ -1,6 +1,9 @@
 {{ define "implDirectives" }}{{ $in := .DirectiveObjName }}
 	{{- range $i, $directive := .ImplDirectives -}}
 		directive{{add $i 1}} := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.{{$directive.Name|ucFirst}} == nil {
+				return directive0(ctx)
+			}
 			{{- range $arg := $directive.Args }}
 				{{- if notNil "Value" $arg }}
 						{{ $arg.VarName }}, err := ec.{{ $arg.TypeReference.UnmarshalFunc }}(ctx, {{ $arg.Value | dump }})

--- a/codegen/field.go
+++ b/codegen/field.go
@@ -95,6 +95,18 @@ func (b *builder) bindField(obj *Object, f *Field) error {
 		f.GoReceiverName = "ec"
 		f.GoFieldName = "introspectType"
 		return nil
+	case f.Name == "_entities":
+		f.GoFieldType = GoFieldMethod
+		f.GoReceiverName = "ec"
+		f.GoFieldName = "__resolve_entities"
+		f.MethodHasContext = true
+		return nil
+	case f.Name == "_service":
+		f.GoFieldType = GoFieldMethod
+		f.GoReceiverName = "ec"
+		f.GoFieldName = "__resolve__service"
+		f.MethodHasContext = true
+		return nil
 	case obj.Root:
 		f.IsResolver = true
 		return nil

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -171,6 +171,7 @@ func Funcs() template.FuncMap {
 		"lookupImport":  CurrentImports.Lookup,
 		"go":            ToGo,
 		"goPrivate":     ToGoPrivate,
+		"title":         strings.Title,
 		"add": func(a, b int) int {
 			return a + b
 		},

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/99designs/gqlgen
 
+go 1.12
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-chi/chi v3.3.2+incompatible
@@ -19,7 +21,7 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/urfave/cli v1.20.0
 	github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e
-	github.com/vektah/gqlparser v1.1.2
+	github.com/vektah/gqlparser v1.1.3-0.20190716023015-7ceb135a49ae
 	golang.org/x/tools v0.0.0-20190515012406-7d7faa4812bd
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e h1:+w0Zm/9gaWp
 github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
 github.com/vektah/gqlparser v1.1.2 h1:ZsyLGn7/7jDNI+y4SEhI4yAxRChlv15pUHMjijT+e68=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/vektah/gqlparser v1.1.3-0.20190716023015-7ceb135a49ae h1:uz9ow6BnGFx1Ls8lqd+bLqImc+EcK0PdaoPe/msHaiE=
+github.com/vektah/gqlparser v1.1.3-0.20190716023015-7ceb135a49ae/go.mod h1:bkVf0FX+Stjg/MHnm8mEyubuaArhNEqfQhF+OTiAL74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180404174746-b3c676e531a6 h1:mge3qS/eMvcfyIAzTMOAy0XUzWG6Lk0N4M8zjuSmdco=
 golang.org/x/net v0.0.0-20180404174746-b3c676e531a6/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -31,6 +31,10 @@ type (
 		DefaultValue *string
 		Type         *Type
 	}
+
+	Service struct {
+		SDL string `json:"sdl"`
+	}
 )
 
 func WrapSchema(schema *ast.Schema) *Schema {

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -1,0 +1,336 @@
+package federation
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/99designs/gqlgen/codegen"
+	"github.com/99designs/gqlgen/codegen/config"
+	"github.com/99designs/gqlgen/codegen/templates"
+	"github.com/99designs/gqlgen/plugin"
+	"github.com/vektah/gqlparser"
+	"github.com/vektah/gqlparser/ast"
+	"github.com/vektah/gqlparser/formatter"
+)
+
+type federation struct {
+	SDL      string
+	Entities []*Entity
+}
+
+// New returns a federation plugin that injects
+// federated directives and types into the schema
+func New() plugin.Plugin {
+	return &federation{}
+}
+
+func (f *federation) Name() string {
+	return "federation"
+}
+
+func (f *federation) MutateConfig(cfg *config.Config) error {
+	entityFields := map[string]config.TypeMapField{}
+	for _, e := range f.Entities {
+		entityFields[e.ResolverName] = config.TypeMapField{Resolver: true}
+		for _, r := range e.Requires {
+			if cfg.Models[e.Name].Fields == nil {
+				model := cfg.Models[e.Name]
+				model.Fields = map[string]config.TypeMapField{}
+				cfg.Models[e.Name] = model
+			}
+			cfg.Models[e.Name].Fields[r.Name] = config.TypeMapField{Resolver: true}
+		}
+	}
+	builtins := config.TypeMap{
+		"_Service": {
+			Model: config.StringList{
+				"github.com/99designs/gqlgen/graphql/introspection.Service",
+			},
+		},
+		"_Any": {Model: config.StringList{"github.com/99designs/gqlgen/graphql.Map"}},
+		"Entity": {
+			Fields: entityFields,
+		},
+	}
+	for typeName, entry := range builtins {
+		if cfg.Models.Exists(typeName) {
+			return fmt.Errorf("%v already exists which must be reserved when Federation is enabled", typeName)
+		}
+		cfg.Models[typeName] = entry
+	}
+	cfg.Directives["external"] = config.DirectiveConfig{SkipRuntime: true}
+	cfg.Directives["requires"] = config.DirectiveConfig{SkipRuntime: true}
+	cfg.Directives["provides"] = config.DirectiveConfig{SkipRuntime: true}
+	cfg.Directives["key"] = config.DirectiveConfig{SkipRuntime: true}
+	cfg.Directives["extends"] = config.DirectiveConfig{SkipRuntime: true}
+
+	return nil
+}
+
+func (f *federation) InjectSources(cfg *config.Config) {
+	cfg.AdditionalSources = append(cfg.AdditionalSources, f.getSource(false))
+	f.setEntities(cfg)
+	s := "type Entity {\n"
+	for _, e := range f.Entities {
+		s += fmt.Sprintf("\t%s(%s: %s): %s!\n", e.ResolverName, e.FieldName, e.FieldTypeGQL, e.Name)
+	}
+	s += "}"
+	cfg.AdditionalSources = append(cfg.AdditionalSources, &ast.Source{Name: "entity.graphql", Input: s, BuiltIn: true})
+}
+
+func (f *federation) MutateSchema(s *ast.Schema) error {
+	// --- Set _Entity Union ---
+	union := &ast.Definition{
+		Name:        "_Entity",
+		Kind:        ast.Union,
+		Description: "A union unifies all @entity types (TODO: interfaces)",
+		Types:       []string{},
+	}
+	for _, ent := range f.Entities {
+		union.Types = append(union.Types, ent.Name)
+		s.AddPossibleType("_Entity", ent.Def)
+		// s.AddImplements(ent.Name, union) // Do we need this?
+	}
+	s.Types[union.Name] = union
+
+	// --- Set _entities query ---
+	fieldDef := &ast.FieldDefinition{
+		Name: "_entities",
+		Type: ast.NonNullListType(ast.NamedType("_Entity", nil), nil),
+		Arguments: ast.ArgumentDefinitionList{
+			{
+				Name: "representations",
+				Type: ast.NonNullListType(ast.NonNullNamedType("_Any", nil), nil),
+			},
+		},
+	}
+	if s.Query == nil {
+		s.Query = &ast.Definition{
+			Kind: ast.Object,
+			Name: "Query",
+		}
+		s.Types["Query"] = s.Query
+	}
+	s.Query.Fields = append(s.Query.Fields, fieldDef)
+
+	// --- set _Service type ---
+	typeDef := &ast.Definition{
+		Kind: ast.Object,
+		Name: "_Service",
+		Fields: ast.FieldList{
+			&ast.FieldDefinition{
+				Name: "sdl",
+				Type: ast.NonNullNamedType("String", nil),
+			},
+		},
+	}
+	s.Types[typeDef.Name] = typeDef
+
+	// --- set _service query ---
+	_serviceDef := &ast.FieldDefinition{
+		Name: "_service",
+		Type: ast.NonNullNamedType("_Service", nil),
+	}
+	s.Query.Fields = append(s.Query.Fields, _serviceDef)
+	return nil
+}
+
+func (f *federation) getSource(builtin bool) *ast.Source {
+	return &ast.Source{
+		Name: "federation.graphql",
+		Input: `# Declarations as required by the federation spec 
+# See: https://www.apollographql.com/docs/apollo-server/federation/federation-spec/
+
+scalar _Any
+scalar _FieldSet
+
+directive @external on FIELD_DEFINITION
+directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+directive @extends on OBJECT
+`,
+		BuiltIn: builtin,
+	}
+}
+
+// Entity represents a federated type
+// that was declared in the GQL schema.
+type Entity struct {
+	Name         string // The same name as the type declaration
+	FieldName    string // The field name declared in @key
+	FieldTypeGo  string // The Go representation of that field type
+	FieldTypeGQL string // The GQL represetation of that field type
+	ResolverName string // The resolver name, such as FindUserByID
+	Def          *ast.Definition
+	Requires     []*Requires
+}
+
+// Requires represents an @requires clause
+type Requires struct {
+	Name   string          // the name of the field
+	Fields []*RequireField // the name of the sibling fields
+}
+
+// RequireField is similar to an entity but it is a field not
+// an object
+type RequireField struct {
+	Name          string                // The same name as the type declaration
+	NameGo        string                // The Go struct field name
+	TypeReference *config.TypeReference // The Go representation of that field type
+}
+
+func (f *federation) GenerateCode(data *codegen.Data) error {
+	sdl, err := f.getSDL(data.Config)
+	if err != nil {
+		return err
+	}
+	f.SDL = sdl
+	data.Objects.ByName("Entity").Root = true
+	for _, e := range f.Entities {
+		obj := data.Objects.ByName(e.Name)
+		for _, f := range obj.Fields {
+			if f.Name == e.FieldName {
+				e.FieldTypeGo = f.TypeReference.GO.String()
+			}
+			for _, r := range e.Requires {
+				for _, rf := range r.Fields {
+					if rf.Name == f.Name {
+						rf.TypeReference = f.TypeReference
+						rf.NameGo = f.GoFieldName
+					}
+				}
+			}
+		}
+	}
+	return templates.Render(templates.Options{
+		Template:        tmpl,
+		PackageName:     data.Config.Exec.Package,
+		Filename:        "service.go",
+		Data:            f,
+		GeneratedHeader: true,
+	})
+}
+
+func (f *federation) setEntities(cfg *config.Config) {
+	schema, err := cfg.LoadSchema()
+	if err != nil {
+		panic(err)
+	}
+	for _, schemaType := range schema.Types {
+		switch schemaType.Kind {
+		case ast.Object:
+			dir := schemaType.Directives.ForName("key") // TODO: interfaces
+			if dir != nil {
+				fieldName := dir.Arguments[0].Value.Raw // TODO: multiple arguments,a nd multiple keys
+				if strings.Contains(fieldName, " ") {
+					panic("only single fields are currently supported in @key declaration")
+				}
+				field := schemaType.Fields.ForName(fieldName)
+				requires := []*Requires{}
+				for _, f := range schemaType.Fields {
+					dir := f.Directives.ForName("requires")
+					if dir == nil {
+						continue
+					}
+					fields := strings.Split(dir.Arguments[0].Value.Raw, " ")
+					requireFields := []*RequireField{}
+					for _, f := range fields {
+						requireFields = append(requireFields, &RequireField{
+							Name: f,
+						})
+					}
+					requires = append(requires, &Requires{
+						Name:   f.Name,
+						Fields: requireFields,
+					})
+				}
+				f.Entities = append(f.Entities, &Entity{
+					Name:         schemaType.Name,
+					FieldName:    fieldName,
+					FieldTypeGQL: field.Type.String(),
+					Def:          schemaType,
+					ResolverName: fmt.Sprintf("find%sBy%s", schemaType.Name, templates.ToGo(fieldName)),
+					Requires:     requires,
+				})
+			}
+		}
+	}
+}
+
+func (f *federation) getSDL(c *config.Config) (string, error) {
+	sources := []*ast.Source{f.getSource(true)}
+	for _, filename := range c.SchemaFilename {
+		filename = filepath.ToSlash(filename)
+		var err error
+		var schemaRaw []byte
+		schemaRaw, err = ioutil.ReadFile(filename)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "unable to open schema: "+err.Error())
+			os.Exit(1)
+		}
+		sources = append(sources, &ast.Source{Name: filename, Input: string(schemaRaw)})
+	}
+	schema, err := gqlparser.LoadSchema(sources...)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	formatter.NewFormatter(&buf).FormatSchema(schema)
+	return buf.String(), nil
+}
+
+var tmpl = `
+{{ reserveImport "context"  }}
+{{ reserveImport "errors"  }}
+
+{{ reserveImport "github.com/99designs/gqlgen/graphql/introspection" }}
+
+func (ec *executionContext) __resolve__service(ctx context.Context) (introspection.Service, error) {
+	if ec.DisableIntrospection {
+		return introspection.Service{}, errors.New("federated introspection disabled")
+	}
+	return introspection.Service{
+		SDL: ` + "`{{.SDL}}`" + `,
+	}, nil
+}
+
+func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]_Entity, error) {
+	list := []_Entity{}
+	for _, rep := range representations {
+		typeName, ok := rep["__typename"].(string)
+		if !ok {
+			return nil, errors.New("__typename must be an existing string")
+		}
+		switch typeName {
+		{{ range .Entities }}
+		case "{{.Name}}":
+			id, ok := rep["{{.FieldName}}"].({{.FieldTypeGo}})
+			if !ok {
+				return nil, errors.New("opsies")
+			}
+			resp, err := ec.resolvers.Entity().{{.ResolverName | title}}(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			{{ range .Requires }}
+				{{ range .Fields}}
+					resp.{{.NameGo}}, err = ec.{{.TypeReference.UnmarshalFunc}}(ctx, rep["{{.Name}}"])
+					if err != nil {
+						return nil, err
+					}
+				{{ end }}
+			{{ end }}
+			list = append(list, resp)
+		{{ end }}
+		default:
+			return nil, errors.New("unknown type: "+typeName)
+		}
+	}
+	return list, nil
+}
+`

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -209,8 +209,8 @@ func (f *federation) GenerateCode(data *codegen.Data) error {
 	}
 	return templates.Render(templates.Options{
 		Template:        tmpl,
-		PackageName:     data.Config.Exec.Package,
-		Filename:        "service.go",
+		PackageName:     data.Config.Service.Package,
+		Filename:        data.Config.Service.Filename,
 		Data:            f,
 		GeneratedHeader: true,
 	})

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -222,8 +222,7 @@ func (f *federation) setEntities(cfg *config.Config) {
 		panic(err)
 	}
 	for _, schemaType := range schema.Types {
-		switch schemaType.Kind {
-		case ast.Object:
+		if schemaType.Kind == ast.Object {
 			dir := schemaType.Directives.ForName("key") // TODO: interfaces
 			if dir != nil {
 				fieldName := dir.Arguments[0].Value.Raw // TODO: multiple arguments,a nd multiple keys

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -63,11 +63,7 @@ func (m *Plugin) Name() string {
 }
 
 func (m *Plugin) MutateConfig(cfg *config.Config) error {
-	if err := cfg.Check(); err != nil {
-		return err
-	}
-
-	schema, _, err := cfg.LoadSchema()
+	schema, err := cfg.LoadSchema()
 	if err != nil {
 		return err
 	}
@@ -88,11 +84,18 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 		PackageName: cfg.Model.Package,
 	}
 
+	var hasEntity bool
 	for _, schemaType := range schema.Types {
 		if cfg.Models.UserDefined(schemaType.Name) {
 			continue
 		}
-
+		var ent bool
+		for _, dir := range schemaType.Directives {
+			if dir.Name == "key" {
+				hasEntity = true
+				ent = true
+			}
+		}
 		switch schemaType.Kind {
 		case ast.Interface, ast.Union:
 			it := &Interface{
@@ -112,6 +115,9 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 
 			for _, implementor := range schema.GetImplements(schemaType) {
 				it.Implements = append(it.Implements, implementor.Name)
+			}
+			if ent { // only when Object. Directive validation should have occured on InputObject otherwise.
+				it.Implements = append(it.Implements, "_Entity")
 			}
 
 			for _, field := range schemaType.Fields {
@@ -200,6 +206,14 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 		case ast.Scalar:
 			b.Scalars = append(b.Scalars, schemaType.Name)
 		}
+	}
+
+	if hasEntity {
+		it := &Interface{
+			Description: "_Entity represents all types with @key",
+			Name:        "_Entity",
+		}
+		b.Interfaces = append(b.Interfaces, it)
 	}
 
 	sort.Slice(b.Enums, func(i, j int) bool { return b.Enums[i].Name < b.Enums[j].Name })

--- a/plugin/modelgen/models.go
+++ b/plugin/modelgen/models.go
@@ -116,7 +116,7 @@ func (m *Plugin) MutateConfig(cfg *config.Config) error {
 			for _, implementor := range schema.GetImplements(schemaType) {
 				it.Implements = append(it.Implements, implementor.Name)
 			}
-			if ent { // only when Object. Directive validation should have occured on InputObject otherwise.
+			if ent { // only when Object. Directive validation should have occurred on InputObject otherwise.
 				it.Implements = append(it.Implements, "_Entity")
 			}
 

--- a/plugin/modelgen/models_test.go
+++ b/plugin/modelgen/models_test.go
@@ -14,6 +14,7 @@ import (
 func TestModelGeneration(t *testing.T) {
 	cfg, err := config.LoadConfig("testdata/gqlgen.yml")
 	require.NoError(t, err)
+	require.NoError(t, cfg.Check())
 	p := Plugin{}
 	require.NoError(t, p.MutateConfig(cfg))
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -18,3 +18,7 @@ type ConfigMutator interface {
 type CodeGenerator interface {
 	GenerateCode(cfg *codegen.Data) error
 }
+
+type SourcesInjector interface {
+	InjectSources(cfg *config.Config)
+}

--- a/plugin/resolvergen/resolver_test.go
+++ b/plugin/resolvergen/resolver_test.go
@@ -18,7 +18,7 @@ func TestPlugin(t *testing.T) {
 	require.NoError(t, err)
 	p := Plugin{}
 
-	data, err := codegen.BuildData(cfg)
+	data, err := codegen.BuildData(cfg, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/plugin/schemaconfig/schemaconfig.go
+++ b/plugin/schemaconfig/schemaconfig.go
@@ -19,11 +19,7 @@ func (m *Plugin) Name() string {
 }
 
 func (m *Plugin) MutateConfig(cfg *config.Config) error {
-	if err := cfg.Check(); err != nil {
-		return err
-	}
-
-	schema, _, err := cfg.LoadSchema()
+	schema, err := cfg.LoadSchema()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch adds the option for users to specific the filename and/or
package of the `service.go` file. To configure, users will need to add a
new section like the following to their `gqlgen.yml` file similar to the
ones that exist now for `exec` and `resolver:

```
service:
 filename: generated/service.go
  package: generated
```

I'm not sure this is this right approach to adding this configuration (should it be part of the plugin system instead?) - but I figured this patch was simple enough as a starting point for discussion. LMK 